### PR TITLE
Ignore data and results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,6 @@ nbdist/
 .vscode/
 bin/
 
-### Results files (.json, .html)###
-results/
-guids/
+### Input and output files (.txt, .json)###
+results/*.json
+guids/**/*.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ── Stage 1: Build ───────────────────────────────────────────────────────────
 # Uses the official Maven + JDK 21 image to compile and package the fat JAR.
-FROM maven:3.9.11-eclipse-temurin-21 AS build
+FROM maven:3.9.15-eclipse-temurin-21 AS build
 
 WORKDIR /build
 
@@ -16,7 +16,7 @@ RUN mvn package -DskipTests -q
 # Minimal JRE-only image keeps the final image small.
 # Use a non-alpine Temurin JRE base to avoid known Alpine vulnerabilities
 # and receive regular security updates (Ubuntu Jammy-based image).
-FROM eclipse-temurin:21-jre-jammy
+FROM eclipse-temurin:21-jre-jammy-latest
 
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN mvn package -DskipTests -q
 # Minimal JRE-only image keeps the final image small.
 # Use a non-alpine Temurin JRE base to avoid known Alpine vulnerabilities
 # and receive regular security updates (Ubuntu Jammy-based image).
-FROM eclipse-temurin:21-jre-jammy-latest
+FROM eclipse-temurin:21-jre-jammy
 
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 

--- a/get_non_pass_results.sh
+++ b/get_non_pass_results.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Run in a directory containing JSON files with Champion test results.
 # Generates a CSV file with the non-pass results.
 {

--- a/get_non_pass_results.sh
+++ b/get_non_pass_results.sh
@@ -1,3 +1,5 @@
+# Run in a directory containing JSON files with Champion test results.
+# Generates a CSV file with the non-pass results.
 {
   echo "file,test_name,result"
   for f in *.json; do

--- a/src/main/java/cessda/cmv/benchmark/tenant/TenantAuthFilter.java
+++ b/src/main/java/cessda/cmv/benchmark/tenant/TenantAuthFilter.java
@@ -39,7 +39,9 @@ public class TenantAuthFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getServletPath();
 
-        // Exempt health checks and the static dashboard HTML/assets.
+        // Exempt health checks, the static dashboard HTML/assets, and
+        // the SpringDoc/Swagger UI paths so the API documentation is
+        // accessible without an API key.
         //
         // Spring Boot's WelcomePageHandlerMapping internally forwards
         // "GET /" to "/index.html" before this filter evaluates the
@@ -54,7 +56,8 @@ public class TenantAuthFilter extends OncePerRequestFilter {
             || path.equals("/detail.html")
             || path.startsWith("/css/")
             || path.startsWith("/js/")
-            || path.equals("/favicon.ico");
+            || path.equals("/favicon.ico")
+            || path.startsWith("/api-docs");
     }
 
     @Override


### PR DESCRIPTION
Updated .gitignore to exclude text and json files from guids and results directories. 
TenantAuthFilter.shouldNotFilter() now exempts all /api-docs/** paths so the SpringDoc OpenAPI spec and Swagger UI are accessible without an X-API-Key header.
Dockerfile: bumped JDK version. Don't use 'latest' as build may not be repeatable.
Added get_non_pass_results.sh: a utility script to be run in a directory containing JSON files with Champion test results to generate a CSV file with the non-pass results for further analysis.